### PR TITLE
Fix amazon_s3_hooks.rb

### DIFF
--- a/lib/amazon_s3_hooks.rb
+++ b/lib/amazon_s3_hooks.rb
@@ -2,6 +2,6 @@
 class AmazonS3Hooks < Redmine::Hook::ViewListener
 
   def view_layouts_base_html_head(context = {})
-    javascript_include_tag 'redmine_s3.js', :plugin => 'redmine_s3'
+    javascript_include_tag 'redmine_s3.js', :plugin => 'amazon_s3'
   end
 end


### PR DESCRIPTION
Javascript file is searching in the redmine_s3 directory instead of amazon_s3.
According to the documentation the plugin should be installed in amazon_s3 directory so plugin_assets are compiled to the specified directory.